### PR TITLE
Changed footer linkedin href

### DIFF
--- a/site/themes/hugo-strata-theme/layouts/partials/footer.html
+++ b/site/themes/hugo-strata-theme/layouts/partials/footer.html
@@ -14,7 +14,7 @@
 		<li><a href="//github.com/{{ . }}" target="_blank" class="icon fa-github"><span class="label">Github</span></a></li>
 		{{ end }}
 		{{ with .Site.Params.sidebar.linkedin }}
-		<li><a href="{{ . }}" target="_blank" class="icon fa-linkedin-square"><span class="label">Linkedin</span></a></li>
+		<li><a href="//linkedin.com/in/{{ . }}" target="_blank" class="icon fa-linkedin-square"><span class="label">Linkedin</span></a></li>
 		{{ end }}
 		{{ with .Site.Params.sidebar.dribbble }}
 		<li><a href="//dribbble.com/{{ . }}" target="_blank" class="icon fa-dribbble"><span class="label">Dribbble</span></a></li>


### PR DESCRIPTION
Previous LinkedIn href was just pointing to {{ . }} unlike the other tags. Changed to href="//linkedin.com/in/{{ . }}" so now input on config.toml links correctly to LinkedIn